### PR TITLE
Add Kai MAI scoring system with daily score persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,3 +171,10 @@ cython_debug/
 
 .env
 .env.prod.do
+
+# Credentials / service account keys — never commit
+secure_credentials/
+assets/*.json
+*service_account*.json
+*-service-account*.json
+*drunr-prod*.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,72 @@
+# BabbleBeaver
+
+Open-source, privacy-focused conversational AI platform built with FastAPI.
+
+## Tech Stack
+- **Backend:** FastAPI + Uvicorn (Python 3.9+)
+- **Database:** SQLite (dev) / PostgreSQL (prod) via SQLAlchemy ORM
+- **LLM Providers:** Google Gemini/Vertex AI (primary, fine-tuned), OpenAI, Ollama, OpenRouter, HuggingFace, Anthropic, Cohere
+- **Deployment:** Docker, GitHub Actions CI/CD → Google Artifact Registry → Kubernetes / DigitalOcean
+
+## Running Locally
+```bash
+source venv/bin/activate
+pip install -r requirements.txt
+uvicorn main:app --reload
+```
+Access at http://localhost:8000 | API docs at http://localhost:8000/docs
+
+## Project Structure
+- `main.py` — FastAPI app entry point
+- `ai_configurator.py` — LLM provider orchestration
+- `llm_manager.py` — Multi-provider fallback manager
+- `database.py` — SQLAlchemy ORM models (incl. `DailyScore` snapshots)
+- `context_manager.py` — Conversation context handling
+- `user_context.py` — Fetches user health profile/biometrics from user_service
+- `scoring.py` — Deterministic Kai MAI scoring engine (implements SCORING.md)
+- `daily_scores.py` — Persists/retrieves daily score snapshots (drift baselines)
+- `SCORING.md` — Authoritative scoring rules (18 rules + meal-level mode)
+- `cost_estimator.py` — Multi-provider cost comparison
+- `model_config/` — Model definitions (model_config.ini)
+- `templates/` — HTML UI (chat, admin)
+- `static/` — Frontend assets
+- `modules/` — Feature modules (buildly-collect, digitalocean, gemini)
+- `tools/` — Test & migration utilities
+- `ops/` — Operations (PID management)
+
+## Key Commands
+```bash
+# Database migration
+python3 tools/migrate_database.py --dry-run
+python3 tools/migrate_database.py
+
+# Tests
+python3 tools/test_database.py
+python3 tools/test_context_aware.py
+python3 tools/test_scoring.py   # scoring engine unit tests (pure, no network)
+```
+
+## Kai Scoring System
+- Rules live in `SCORING.md` and are **authoritative** — `scoring.py` implements
+  them exactly; never let the LLM compute the math.
+- Foundation scores (Rules 1–10) feed composites (Rules 11–18); CGM scores are
+  gated on connection + consent. Missing inputs flag a score incomplete (never
+  estimated).
+- `level="meal"` mode scales daily targets by `meal_divisor` (default 3) for
+  per-dish ranking; `level="daily"` (default) is for user adherence.
+- `/chatbot` computes scores from user_service context, upserts a per-day
+  `DailyScore` row, and injects a `KAI HEALTH SCORES` block into Kai's prompt.
+
+## Environment
+- Config via `.env` (API keys, GCP project settings, database URL)
+- Model config via `model_config/model_config.ini`
+- Primary fine-tuned model: `kai_fine_2_5_v2` on Vertex AI
+
+## CI/CD
+- `dev` branch → dev-build.yml → dev image
+- `prod` branch → prod-build.yml → prod image → Artifact Registry → K8s manifest update
+
+## Important Notes
+- Never commit `.env` or credential JSON files
+- CORS domains configured via `CORS_ALLOWED_DOMAINS` env var
+- Database auto-switches between SQLite/PostgreSQL based on `DATABASE_URL` presence

--- a/SCORING.md
+++ b/SCORING.md
@@ -1,0 +1,541 @@
+# KAI MAI SCORING SYSTEM — HARD RULES
+
+These rules are authoritative. When computing any Kai score, follow them exactly. Do not infer, approximate, or substitute values unless a rule explicitly permits a fallback.
+
+---
+
+## RULE 0 — UNIVERSAL SCORE CONSTRAINTS
+
+- All scores output a value between **0 and 100**, inclusive.
+- Never return a score below 0 or above 100.
+- Scores are expressed as a **percentage (%)**.
+- Round final scores to the nearest whole number unless instructed otherwise.
+- Two formula types exist:
+  - **Higher is better:** `Score = (Actual ÷ Target) × 100`, capped at 100.
+  - **Lower is better:** `Score = (Target ÷ Actual) × 100`, capped at 100. If Actual ≤ Target, score = 100.
+
+---
+
+## RULE 1 — PROTEIN ADEQUACY SCORE
+**Type:** Higher is better.
+
+**Target (use the higher of the two):**
+- 100g protein/day
+- 1.2g × user body weight in kg
+
+**Formula:**
+```
+Score = (Actual protein consumed ÷ Protein target) × 100
+```
+
+**Hard constraints:**
+- NEVER use a target below 100g, even for very light users.
+- If body weight is unknown, use 100g as the default target.
+- Cap at 100. Do not reward exceeding the target.
+
+---
+
+## RULE 2 — FIBER ADEQUACY SCORE
+**Type:** Higher is better.
+
+**Target (use one of the following, in order of availability):**
+1. 30g/day (default)
+2. 14g per 1,000 calories consumed (calorie-based alternative)
+
+**Formula:**
+```
+Score = (Actual fiber consumed ÷ Fiber target) × 100
+```
+
+**Hard constraints:**
+- Default to 30g/day unless calorie data is available and the calorie-based target is preferred.
+- Cap at 100.
+
+---
+
+## RULE 3 — CALORIE ALIGNMENT SCORE
+**Type:** Proximity to target (not higher-is-better or lower-is-better).
+
+**Target (use in order of availability):**
+1. Provider-set calorie target
+2. User maintenance calories minus 15%
+3. Female default: 1,600 cal/day
+4. Male default: 1,900 cal/day
+
+**Formula:**
+```
+Difference% = |Actual calories - Target calories| ÷ Target calories × 100
+Score = 100 - Difference%
+```
+
+**Hard constraints:**
+- Use absolute value — being over OR under the target both reduce the score equally.
+- Cap at 100, floor at 0.
+- Never use a provider target and a default target simultaneously.
+
+---
+
+## RULE 4 — SODIUM CONTROL SCORE
+**Type:** Lower is better.
+
+**Target:** 2,300mg/day  
+**Meal-level fallback:** 767mg/meal (2,300 ÷ 3)
+
+**Formula:**
+```
+If Actual ≤ 2,300mg: Score = 100
+If Actual > 2,300mg: Score = (2,300 ÷ Actual) × 100
+```
+
+**Hard constraints:**
+- Never penalize sodium under the target.
+- Use daily total when available; use meal-level fallback only when daily total is unavailable.
+
+---
+
+## RULE 5 — ADDED SUGAR CONTROL SCORE
+**Type:** Lower is better.
+
+**Target calculation:**
+```
+Sugar calorie target = Daily calorie target × 10%
+Sugar gram target = Sugar calorie target ÷ 4
+```
+
+**Formula:**
+```
+If Actual added sugar ≤ Sugar gram target: Score = 100
+If Actual added sugar > Sugar gram target: Score = (Sugar gram target ÷ Actual added sugar) × 100
+```
+
+**Hard constraints:**
+- Always derive the gram target from the calorie target — do not use a fixed gram default.
+- Use 4 cal/gram as the conversion factor for sugar. Never change this.
+- Never penalize sugar intake under the target.
+
+---
+
+## RULE 6 — SATURATED FAT CONTROL SCORE
+**Type:** Lower is better.
+
+**Target calculation:**
+```
+Sat fat calorie target = Daily calorie target × 10%
+Sat fat gram target = Sat fat calorie target ÷ 9
+```
+
+**Formula:**
+```
+If Actual sat fat ≤ Sat fat gram target: Score = 100
+If Actual sat fat > Sat fat gram target: Score = (Sat fat gram target ÷ Actual sat fat) × 100
+```
+
+**Hard constraints:**
+- Always derive the gram target from the calorie target — do not use a fixed gram default.
+- Use 9 cal/gram as the conversion factor for fat. Never change this.
+- Never penalize sat fat intake under the target.
+
+---
+
+## RULE 7 — HYDRATION ALIGNMENT SCORE
+**Type:** Higher is better.
+
+**Base targets:**
+- Female: 2.7 liters/day
+- Male: 3.7 liters/day
+
+**Adjustments (additive):**
+- +0.25L per 30 active minutes (or fraction thereof)
+- +0.5L if temperature > 80°F
+
+**Formula:**
+```
+Final target = Base target + activity adjustment + heat adjustment
+Score = (Actual water intake ÷ Final target) × 100
+```
+
+**Hard constraints:**
+- Always apply adjustments before computing the score — never score against the unadjusted base target when adjustment data is available.
+- Cap at 100.
+- If sex is unknown, use female default (2.7L) as the conservative baseline.
+
+---
+
+## RULE 8 — SLEEP QUALITY SCORE
+**Type:** Weighted composite. Higher is better.
+
+**Weights:**
+- Sleep Duration: 35%
+- Sleep Efficiency: 30%
+- Sleep Consistency: 20%
+- Sleep Debt: 15%
+
+**Subscore formulas:**
+
+**Duration:**
+```
+If 7–9 hours: 100
+If < 7 hours: (Actual hours ÷ 7) × 100
+If > 9 hours: (9 ÷ Actual hours) × 100
+```
+
+**Efficiency:**
+```
+Score = (Actual efficiency% ÷ 85) × 100
+```
+
+**Consistency:**
+```
+If timing varies ≤ 60 min: 100
+If timing varies > 60 min: (60 ÷ Actual variation in minutes) × 100
+```
+
+**Sleep Debt:**
+```
+If no debt: 100
+If debt exists: 100 - (Debt hours × 15)
+Floor at 0.
+```
+
+**Final formula:**
+```
+Sleep Quality = (Duration × 0.35) + (Efficiency × 0.30) + (Consistency × 0.20) + (Debt × 0.15)
+```
+
+**Hard constraints:**
+- All four subscores must be computed. Do not skip a subscore and redistribute weights.
+- Sleep Debt subscore floors at 0 — never go negative.
+- Efficiency target is fixed at 85%. Do not adjust.
+
+---
+
+## RULE 9 — ACTIVITY ALIGNMENT SCORE
+**Type:** Weighted composite. Higher is better.
+
+**Weights:**
+- Step Target: 30%
+- Active Minutes: 30%
+- Exercise Consistency: 20%
+- Baseline Improvement: 20%
+
+**Targets:**
+- Steps: 8,000/day
+- Active minutes: 21/day (150 ÷ 7)
+- Exercise sessions: 2/week
+
+**Subscore formulas:**
+```
+Steps Score = (Actual steps ÷ 8,000) × 100
+Active Minutes Score = (Actual active minutes ÷ 21) × 100
+Exercise Consistency Score = (Actual weekly sessions ÷ 2) × 100
+Baseline Improvement Score = (Current activity level ÷ Baseline activity level) × 100
+```
+
+**Final formula:**
+```
+Activity Alignment = (Steps × 0.30) + (Active Minutes × 0.30) + (Exercise Consistency × 0.20) + (Baseline Improvement × 0.20)
+```
+
+**Hard constraints:**
+- Cap all subscores at 100 before applying weights.
+- If baseline activity is unavailable, exclude Baseline Improvement and redistribute its 20% weight equally across the other three components (Steps: 37%, Active Minutes: 37%, Exercise Consistency: 26% — approximate).
+- Step target is fixed at 8,000. Do not change without explicit provider override.
+
+---
+
+## RULE 10 — GLUCOSE STABILITY SCORE
+**Type:** Weighted composite. Higher is better.  
+**Activation requirement:** CGM must be connected AND user consent must be active. Never compute without both.
+
+**Weights:**
+- Time in Range: 35%
+- Variability Control: 25%
+- Post-Meal Excursion Control: 20%
+- Mean Glucose Alignment: 10%
+- Time Above Range Control: 10%
+
+**Targets:**
+- Time in range (TIR): ≥70% (range: 70–180 mg/dL)
+- Glucose variability (CV): <36%
+- Post-meal glucose rise: <40 mg/dL
+- Mean glucose: 100 mg/dL
+- Time above range: <25%
+
+**Subscore formulas:**
+```
+TIR Score = (Actual TIR% ÷ 70) × 100
+
+Variability Score = (36 ÷ Actual CV%) × 100
+  → If Actual CV% ≤ 36: Score = 100
+
+Post-Meal Score = (40 ÷ Actual post-meal rise) × 100
+  → If Actual rise ≤ 40: Score = 100
+
+Mean Glucose Score = 100 - (|Actual mean - 100| ÷ 100 × 100)
+
+Time Above Range Score = (25 ÷ Actual time above range%) × 100
+  → If Actual time above range ≤ 25%: Score = 100
+```
+
+**Final formula:**
+```
+Glucose Stability = (TIR × 0.35) + (Variability × 0.25) + (Post-Meal × 0.20) + (Mean Glucose × 0.10) + (Time Above Range × 0.10)
+```
+
+**Hard constraints:**
+- Do not compute or display this score without confirmed CGM connection and active consent.
+- All subscore caps at 100.
+
+---
+
+## RULE 11 — NUTRITION QUALITY SCORE
+**Type:** Weighted composite. Higher is better.
+
+**Weights:**
+- Protein Adequacy: 25%
+- Fiber Adequacy: 20%
+- Calorie Alignment: 15%
+- Glycemic Load Control: 15%
+- Added Sugar Control: 10%
+- Saturated Fat Control: 10%
+- Sodium Control: 5%
+
+**Formula:**
+```
+Nutrition Quality = (Protein × 0.25) + (Fiber × 0.20) + (Calorie × 0.15) + (Glycemic Load × 0.15) + (Added Sugar × 0.10) + (Sat Fat × 0.10) + (Sodium × 0.05)
+```
+
+**Hard constraints:**
+- All component scores must come from their respective scored metrics (Rules 1–6).
+- Weights must sum to 1.00. Do not adjust weights.
+- Glycemic Load Control must be scored before this composite can be computed.
+
+---
+
+## RULE 12 — BODY STATE SCORE
+**Type:** Weighted composite. Higher is better.  
+**Two versions — CGM and non-CGM. Never mix weights between versions.**
+
+**With CGM:**
+- Sleep Quality: 25%
+- Activity Alignment: 20%
+- Recovery Signal: 15%
+- Nutrition Consistency: 15%
+- Hydration Alignment: 10%
+- Glucose Stability: 15%
+
+```
+Body State = (Sleep × 0.25) + (Activity × 0.20) + (Recovery × 0.15) + (Nutrition Consistency × 0.15) + (Hydration × 0.10) + (Glucose × 0.15)
+```
+
+**Without CGM:**
+- Sleep Quality: 29%
+- Activity Alignment: 24%
+- Recovery Signal: 22%
+- Nutrition Consistency: 20%
+- Hydration Alignment: 5%
+
+```
+Body State = (Sleep × 0.29) + (Activity × 0.24) + (Recovery × 0.22) + (Nutrition Consistency × 0.20) + (Hydration × 0.05)
+```
+
+**Hard constraints:**
+- Determine CGM status FIRST. Then lock in the correct weight set.
+- Do not use CGM weights if CGM is disconnected mid-session.
+
+---
+
+## RULE 13 — GLP-1 PROTOCOL ALIGNMENT SCORE
+**Type:** Weighted composite. Higher is better.
+
+**Weights:**
+- Nutrition Alignment: 25%
+- Protein Target Adherence: 20%
+- Activity Alignment: 15%
+- Hydration Alignment: 10%
+- Sleep Consistency: 10%
+- Meal Timing Consistency: 10%
+- Engagement: 10%
+
+**Formula:**
+```
+GLP-1 Protocol Alignment = (Nutrition × 0.25) + (Protein × 0.20) + (Activity × 0.15) + (Hydration × 0.10) + (Sleep Consistency × 0.10) + (Meal Timing × 0.10) + (Engagement × 0.10)
+```
+
+**Hard constraints:**
+- Weights sum to 1.00. Do not redistribute.
+- "Engagement" is a tracked behavioral signal — do not assume 100 if unknown. Default to 0 if no engagement data exists.
+
+---
+
+## RULE 14 — BEHAVIORAL DRIFT SCORE
+**Type:** Risk score. Higher = more risk.  
+**Interpretation is INVERTED from all other scores.**
+
+**Baseline:**
+- Use rolling 14-day or 30-day average.
+- If no baseline exists, use first 7 days of data as baseline.
+- Never score drift without a baseline.
+
+**Weights:**
+- Nutrition Decline: 25%
+- Activity Decline: 20%
+- Sleep Decline: 15%
+- High-Risk Meal Increase: 15%
+- Engagement Decline: 15%
+- Meal Timing Variability: 10%
+
+**Subscore formula (decline metrics):**
+```
+Decline Score = ((Baseline value - Current value) ÷ Baseline value) × 100
+Floor at 0 — improvement does not generate negative drift.
+```
+
+**Final formula:**
+```
+Behavioral Drift = (Nutrition Decline × 0.25) + (Activity Decline × 0.20) + (Sleep Decline × 0.15) + (High-Risk Meal × 0.15) + (Engagement Decline × 0.15) + (Meal Timing Variability × 0.10)
+```
+
+**Interpretation bands:**
+- 0–30: Low Drift
+- 31–60: Moderate Drift
+- 61–100: High Drift
+
+**Hard constraints:**
+- Do NOT invert this score before display. It is intentionally a risk-increasing metric.
+- When used in Overall Adherence (Rule 17), it IS inverted: `Drift Control = 100 - Behavioral Drift`.
+- Decline subscores floor at 0. Improvement in a metric does not pull drift negative.
+
+---
+
+## RULE 15 — MEAL ALIGNMENT SCORE
+**Type:** Weighted composite. Higher is better.
+
+**Weights:**
+- Nutrition Quality: 35%
+- Protocol Fit: 25%
+- Current Body State Fit: 15%
+- Historical Response Fit: 15%
+- Preference Fit: 10%
+
+**Formula:**
+```
+Meal Alignment = (Nutrition Quality × 0.35) + (Protocol Fit × 0.25) + (Body State Fit × 0.15) + (Historical Response × 0.15) + (Preference Fit × 0.10)
+```
+
+**Hard constraints:**
+- Nutrition Quality must be scored per Rule 11 before this composite can be computed.
+- If historical data is unavailable, set Historical Response Fit to 50 (neutral) rather than 0.
+
+---
+
+## RULE 16 — PREDICTED MEAL IMPACT SCORE
+**Type:** Weighted composite. Higher is better.
+
+**Weights:**
+- Meal Alignment: 30%
+- Satiety Potential: 20%
+- Glucose Stability Impact: 20%
+- Energy Stability Impact: 15%
+- Recovery Support: 10%
+- Historical Response Fit: 5%
+
+**Formula:**
+```
+Predicted Meal Impact = (Meal Alignment × 0.30) + (Satiety × 0.20) + (Glucose Impact × 0.20) + (Energy Impact × 0.15) + (Recovery × 0.10) + (Historical Response × 0.05)
+```
+
+**Hard constraints:**
+- Meal Alignment (Rule 15) must be computed first.
+- If no CGM is connected, Glucose Stability Impact must be estimated from meal composition data only — flag the output as estimated.
+
+---
+
+## RULE 17 — OVERALL ADHERENCE SCORE
+**Type:** Weighted composite. Higher is better.  
+**Two versions — CGM and non-CGM. Never mix weights between versions.**
+
+**Drift Control derivation (applies to both versions):**
+```
+Drift Control = 100 - Behavioral Drift Score
+```
+
+**With CGM:**
+- GLP-1 Protocol Alignment: 30%
+- Nutrition Quality: 20%
+- Activity Alignment: 15%
+- Sleep Quality: 10%
+- Engagement: 10%
+- Glucose Stability: 10%
+- Drift Control: 5%
+
+```
+Overall Adherence = (GLP-1 × 0.30) + (Nutrition × 0.20) + (Activity × 0.15) + (Sleep × 0.10) + (Engagement × 0.10) + (Glucose × 0.10) + (Drift Control × 0.05)
+```
+
+**Without CGM:**
+- GLP-1 Protocol Alignment: 34%
+- Nutrition Quality: 24%
+- Activity Alignment: 17%
+- Sleep Quality: 10%
+- Engagement: 10%
+- Drift Control: 5%
+
+```
+Overall Adherence = (GLP-1 × 0.34) + (Nutrition × 0.24) + (Activity × 0.17) + (Sleep × 0.10) + (Engagement × 0.10) + (Drift Control × 0.05)
+```
+
+**Hard constraints:**
+- Always invert Behavioral Drift to Drift Control before applying weight. Never use raw Behavioral Drift score here.
+- CGM status must be determined before selecting weight set.
+
+---
+
+## RULE 18 — RECOMMENDATION CONFIDENCE SCORE
+**Type:** Weighted composite, with penalty deduction. Higher is better.
+
+**Weights:**
+- Nutrition Data Completeness: 25%
+- Wearable Coverage: 20%
+- User History Depth: 20%
+- Similar Meal Evidence: 15%
+- Past Prediction Accuracy: 10%
+- Context Completeness: 10%
+
+**Formula:**
+```
+Base Score = (Nutrition Data × 0.25) + (Wearable Coverage × 0.20) + (User History × 0.20) + (Similar Meal Evidence × 0.15) + (Past Accuracy × 0.10) + (Context × 0.10)
+Final Score = Base Score - Missing Data Penalty
+```
+
+**Hard constraints:**
+- Missing Data Penalty must be explicitly calculated and applied — do not omit it even if small.
+- Floor the final score at 0.
+- This score gates recommendation delivery: low confidence scores should trigger a data-quality warning alongside the recommendation.
+
+---
+
+## GLOBAL HARD CONSTRAINTS (apply to all rules)
+
+1. **Never invent data.** If an input value is missing, apply the documented default or flag the score as incomplete. Do not estimate inputs.
+2. **Weights are fixed.** Do not redistribute component weights unless a rule explicitly provides a fallback redistribution.
+3. **CGM gating is binary.** Either CGM is connected with active consent, or it is not. There is no partial CGM state.
+4. **Scores are unitless percentages.** Never append units (mg, g, L) to a final score output.
+5. **Score computation order matters.** Foundation scores (Rules 1–10) must be computed before composite scores (Rules 11–18) that depend on them.
+6. **Cap before weighting.** In all weighted composites, cap each subscore at 100 before multiplying by its weight.
+7. **Behavioral Drift is the only score where higher = worse.** In all other contexts, higher is better.
+8. **Provider targets override all defaults.** If a provider has set a specific target for a metric, use it. Never silently fall back to a default when a provider target exists.
+
+---
+
+## MEAL-LEVEL SCORING MODE (extension)
+
+All rules above define **daily** targets. When scoring a **single meal** (e.g. ranking dinner options), the engine supports an opt-in `level = "meal"` mode that scales daily intake targets down by a `meal_divisor` (default 3, mirroring the Rule 4 sodium fallback `767mg = 2300 ÷ 3`).
+
+**Scaling in meal mode:**
+- **Protein (Rule 1):** daily target (floor 100g, or `1.2 × kg`) ÷ divisor. *This intentionally relaxes the "never below 100g" daily floor — that floor is a daily constraint and would unfairly penalize any single meal.*
+- **Fiber (Rule 2):** default 30g ÷ divisor. The calorie-based alternative is already portion-proportional and is not scaled.
+- **Calorie / Added Sugar / Saturated Fat (Rules 3, 5, 6):** the default/maintenance calorie target ÷ divisor; sugar and sat-fat gram targets derive from it and scale automatically. A **provider-set** calorie target is used as-is (assumed already per-meal when in meal mode).
+- **Sodium (Rule 4):** unchanged — already has the 767mg/meal fallback.
+
+**Constraint:** Daily mode (`level = "daily"`) remains the default and applies Rules 1–18 verbatim. Meal mode is only for per-meal/per-dish comparisons and must never be used to report a user's daily adherence.

--- a/daily_scores.py
+++ b/daily_scores.py
@@ -1,0 +1,111 @@
+"""
+Daily score persistence.
+
+Bridges the pure scoring engine (scoring.py) and the DailyScore table
+(database.py). On each chat we recompute the user's MAI scores from their latest
+user_service context and upsert today's row — keeping the current day fresh while
+accruing one snapshot per day for drift baselines (SCORING.md Rule 14) and any
+future dashboard/trend views.
+
+Fail-safe: any DB error falls back to an in-memory computation so the chat flow
+is never broken (mirrors user_context's fail-open behavior).
+"""
+
+import logging
+from datetime import date
+from typing import Any, Dict, List, Optional
+
+from database import db_manager, DailyScore
+from scoring import (
+    compute_scores,
+    deserialize_scores,
+    format_scores_block,
+    inputs_from_context,
+    serialize_scores,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def upsert_daily_scores(
+    ctx: Optional[Dict[str, Any]],
+    core_user_uuid: Optional[str],
+    on_date: Optional[date] = None,
+) -> str:
+    """Compute scores from ctx, persist today's snapshot, return the prompt block.
+
+    Without a user identity (anonymous chat) scores are computed but not stored.
+    """
+    scores = compute_scores(inputs_from_context(ctx))
+    block = format_scores_block(scores)
+
+    if not core_user_uuid:
+        return block
+
+    on_date = on_date or date.today()
+    try:
+        with db_manager.get_session() as session:
+            row = (
+                session.query(DailyScore)
+                .filter_by(core_user_uuid=core_user_uuid, score_date=on_date)
+                .first()
+            )
+            payload = serialize_scores(scores)
+            if row:
+                row.scores = payload  # refresh today's snapshot
+            else:
+                session.add(
+                    DailyScore(
+                        core_user_uuid=core_user_uuid,
+                        score_date=on_date,
+                        scores=payload,
+                    )
+                )
+    except Exception as e:
+        logger.warning("Failed to persist daily scores for %s: %s", core_user_uuid, e)
+
+    return block
+
+
+def get_daily_scores(
+    core_user_uuid: str, on_date: Optional[date] = None
+) -> Optional[Dict[str, Any]]:
+    """Return a stored day's serialized scores, or None if absent."""
+    if not core_user_uuid:
+        return None
+    on_date = on_date or date.today()
+    try:
+        with db_manager.get_session() as session:
+            row = (
+                session.query(DailyScore)
+                .filter_by(core_user_uuid=core_user_uuid, score_date=on_date)
+                .first()
+            )
+            return row.scores if row else None
+    except Exception as e:
+        logger.warning("Failed to read daily scores for %s: %s", core_user_uuid, e)
+        return None
+
+
+def get_score_history(
+    core_user_uuid: str, days: int = 30
+) -> List[Dict[str, Any]]:
+    """Return up to `days` most recent stored daily snapshots, oldest first.
+
+    Intended for drift baselines and trend views.
+    """
+    if not core_user_uuid:
+        return []
+    try:
+        with db_manager.get_session() as session:
+            rows = (
+                session.query(DailyScore)
+                .filter_by(core_user_uuid=core_user_uuid)
+                .order_by(DailyScore.score_date.desc())
+                .limit(days)
+                .all()
+            )
+            return [r.to_dict() for r in reversed(rows)]
+    except Exception as e:
+        logger.warning("Failed to read score history for %s: %s", core_user_uuid, e)
+        return []

--- a/database.py
+++ b/database.py
@@ -6,9 +6,12 @@ Supports SQLite for development and PostgreSQL for production.
 """
 
 import os
-from datetime import datetime
+from datetime import datetime, date
 from typing import Optional
-from sqlalchemy import create_engine, Column, Integer, String, Text, DateTime, Boolean, JSON
+from sqlalchemy import (
+    create_engine, Column, Integer, String, Text, DateTime, Date, Boolean, JSON,
+    UniqueConstraint,
+)
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker, Session
 from contextlib import contextmanager
@@ -72,6 +75,36 @@ class APIToken(Base):
             'is_active': self.is_active,
             'is_expired': is_expired,
             'last_used_at': self.last_used_at.isoformat() if self.last_used_at else None
+        }
+
+
+class DailyScore(Base):
+    """Persisted snapshot of a user's MAI scores for a single day.
+
+    One row per (user, date); upserted on each chat so the latest day's scores
+    are fresh while history accrues for drift baselines (SCORING.md Rule 14) and
+    dashboards. `scores` holds the serialized rule output (see scoring.py).
+    """
+    __tablename__ = 'daily_scores'
+    __table_args__ = (
+        UniqueConstraint('core_user_uuid', 'score_date', name='uq_user_score_date'),
+    )
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    core_user_uuid = Column(String(64), nullable=False, index=True)
+    score_date = Column(Date, nullable=False, default=date.today, index=True)
+    scores = Column(JSON, nullable=False)  # {key: {value, complete, note}}
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False)
+
+    def to_dict(self):
+        return {
+            'id': self.id,
+            'core_user_uuid': self.core_user_uuid,
+            'score_date': self.score_date.isoformat() if self.score_date else None,
+            'scores': self.scores,
+            'created_at': self.created_at.isoformat() if self.created_at else None,
+            'updated_at': self.updated_at.isoformat() if self.updated_at else None,
         }
 
 

--- a/example.env
+++ b/example.env
@@ -11,6 +11,17 @@ INITIAL_PROMPT_FILE_PATH=""
 # Google Cloud SQL: postgresql://user:pass@localhost:5432/babblebeaver
 DATABASE_URL=
 
+# user_service microservice (optional) - health profile + Spike biometrics.
+# Enables personalized prompt context when a request includes core_user_uuid.
+# Calls the user_service REST API; secret must match user_service TOKEN_SECRET.
+# The user's identity (core_user_uuid) is read from the signed bearer token on
+# the /chatbot request, not from the request body.
+USER_SERVICE_URL=http://localhost:8001
+USER_SERVICE_TOKEN_SECRET=
+# Dev only: accept bearer tokens without signature verification. Never enable in
+# production (it would let callers forge any core_user_uuid).
+ALLOW_UNVERIFIED_JWT=false
+
 # DigitalOcean Gradient AI Platform
 DIGITALOCEAN_AGENT_ENABLED=false
 DIGITALOCEAN_API_TOKEN=

--- a/main.py
+++ b/main.py
@@ -17,6 +17,8 @@ import openai
 from ai_configurator import AIConfigurator
 from message_logger import MessageLogger
 from response_logger import ChatLogger
+from user_context import fetch_user_context, format_user_context, resolve_identity
+from daily_scores import upsert_daily_scores
 
 from google.cloud import aiplatform, bigquery
 import vertexai
@@ -249,7 +251,7 @@ def vector_search_restaurants(query_text: str, top_k: int = 10) -> list:
 Generate answer with genai(kai_fine_2_5_v2) client from Vertex AI
 return dict
 '''
-def generate_from_v2(user_query: str, search_results: list, project_id, location, endpoint_id) -> str:
+def generate_from_v2(user_query: str, search_results: list, project_id, location, endpoint_id, user_context_block: str = "") -> str:
     """Optimized version - fewer tokens, better accuracy"""
     client = genai.Client(
         vertexai=True,
@@ -305,28 +307,62 @@ def generate_from_v2(user_query: str, search_results: list, project_id, location
         if parts:
             context += f"   Nutrition: {', '.join(parts)}\n"
 
-    prompt = f"""
-    You are Kai, DrunR's AI nutrition guide.
-    Keep answers short unless the user asks for detail.
-    Default answer length: 3 bullets or fewer.
-    Avoid long paragraphs.
-    Avoid repeating the user's question.
-    End with one clear next action when useful.
+    user_context_section = f"\n    {user_context_block}\n" if user_context_block else ""
 
+    prompt = f"""
+    You are Kai, DrunR's AI nutrition guide. Talk like a warm, encouraging friend
+    who happens to know food and health well — natural and conversational, never
+    clinical or robotic. Use "you," skip jargon, and don't restate the question.
+{user_context_section}
     User request:
     {user_query}
 
     Available menu results:
     {context}
 
+    FIRST decide which mode to use:
+
+    INDECISION MODE — use this when the user sounds stuck, torn, or can't choose
+    between options (e.g. "I can't decide," "which one?", "they all look good,"
+    "help me pick," or they list a few items and ask you to choose). Instead of
+    just handing them an answer, gently guide them to their own choice:
+    - Open with one warm, reassuring sentence.
+    - Ask 1-2 short Socratic questions that help them weigh the real menu options
+      against what matters to them right now (e.g. "Are you after something light
+      or something that'll keep you full?", "Do you want to lean into your protein
+      goal today, or just something that sounds good?"). Anchor the questions to
+      the actual menu results and their profile/health data when present.
+    - Offer to narrow it down once they answer. Do NOT lecture or pick for them
+      unless they ask you to. Keep it to a few sentences — skip the 3-part format.
+
+    RECOMMENDATION MODE — use this for normal requests where the user wants a
+    suggestion. Reply in exactly these three parts, with no headers shown to the
+    user other than the bold labels below:
+
+    1. A short, friendly opener (one sentence) and then 1-2 concrete picks — a
+       meal and/or a restaurant from the menu results. Name the dish and the spot,
+       and one quick reason each. Keep it to a couple of sentences, not a long list.
+
+    2. **Why this fits you:** 1-2 short bullets that highlight the specific user
+       profile detail(s) and recent health data you used (e.g. "your resting heart
+       rate is steady at 48 bpm" or "you're pescatarian and avoiding dairy"). Only
+       mention data that is actually present in the USER HEALTH PROFILE above.
+
+    3. A single friendly closing line with one clear next step (a question or
+       suggestion).
+
     Rules:
-    - Use ONLY the available menu results above.
-    - Do NOT invent nutrition, ingredients, restaurant details, or health claims.
-    - If a required field is missing, say it is not available yet.
-    - Prioritize GLP-1-friendly patterns when relevant: higher protein, moderate calories,
-    lower added sugar, avoid very heavy/fried options when possible.
-    - Be friendly, practical, and concise.
-    - Do not provide medical advice.
+    - Use ONLY the available menu results for dish/restaurant facts. Never invent
+      nutrition, ingredients, restaurant details, or health claims.
+    - In INDECISION MODE, only reference dishes/restaurants that appear in the menu
+      results above when framing your questions.
+    - If the user profile or health data is empty, skip part 2 gracefully rather
+      than guessing — just give the picks and the closing line.
+    - Respect dietary preferences, allergies, and GLP-1 medication when present.
+    - Favor GLP-1-friendly patterns when relevant: higher protein, moderate
+      calories, lower added sugar, lighter/non-fried options.
+    - Keep the whole reply tight and human — a few sentences, not an essay.
+    - Be supportive, never preachy. Do not give medical advice.
     """
 
     chunk = client.models.generate_content(
@@ -363,6 +399,23 @@ async def chatbot(request: Request):
     data = await request.json()
     user_message, history, tokens, session_id = data.get("prompt"), data.get("history"), data.get("tokens") , data.get("session_id", '12344412')
 
+    # Identity comes from the signed bearer token, never the request body, so a
+    # caller cannot pull another user's health data by guessing a core_user_uuid.
+    core_user_uuid, bearer_token = resolve_identity(request.headers.get("Authorization"))
+
+    # User health profile + wearable biometrics from user_service (optional)
+    user_context_block = ""
+    if core_user_uuid:
+        user_ctx = await fetch_user_context(core_user_uuid, bearer_token=bearer_token)
+        user_context_block = format_user_context(user_ctx)
+        # Deterministic MAI scores (SCORING.md): persist today's snapshot and
+        # inject the block to weight recommendations.
+        score_block = upsert_daily_scores(user_ctx, core_user_uuid)
+        if score_block:
+            user_context_block = (
+                f"{user_context_block}\n\n{score_block}" if user_context_block else score_block
+            )
+
     # Similarity Search from BigQuery vectorDB
     search_results = vector_search_restaurants(
             query_text=user_message,
@@ -380,7 +433,7 @@ async def chatbot(request: Request):
     response_logger.insert_message(session_id, "user", user_message)
 
     # response = generate_from(full_prompt, project_id, location, endpoint_id)
-    response = generate_from_v2(user_message, search_results, project_id, location, endpoint_id)
+    response = generate_from_v2(user_message, search_results, project_id, location, endpoint_id, user_context_block)
     response_dict = response
 
     message_logger.log_message(user_message, session_id)

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ uvicorn
 watchfiles==0.19.0
 websockets>=11.0.3
 requests
+PyJWT
 openai==1.35.4
 google-genai>=0.6.0
 IPython

--- a/scoring.py
+++ b/scoring.py
@@ -1,0 +1,724 @@
+"""
+Kai MAI Scoring Engine — deterministic implementation of SCORING.md.
+
+Every rule in SCORING.md is implemented here as a pure function so the math is
+exact, testable, and never delegated to the LLM. The orchestration layer
+(`compute_scores`) pulls inputs from the same user_context dict produced by
+user_context.fetch_user_context, computes foundation scores (Rules 1–10) before
+composites (Rules 11–18), enforces CGM gating, and flags any score whose inputs
+are missing rather than inventing data (GLOBAL HARD CONSTRAINT 1).
+
+A score is represented as a ScoreResult: a numeric value in [0, 100] when all
+required inputs are present, or value=None with complete=False otherwise.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Result type and numeric helpers
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ScoreResult:
+    """A single rule's outcome. value is None when inputs are incomplete."""
+
+    name: str
+    value: Optional[float]
+    complete: bool
+    note: str = ""
+
+    @property
+    def display(self) -> str:
+        if self.value is None:
+            return f"{self.name}: n/a ({self.note or 'insufficient data'})"
+        return f"{self.name}: {self.value:.0f}%"
+
+
+def _clamp(score: float, lo: float = 0.0, hi: float = 100.0) -> float:
+    return max(lo, min(hi, score))
+
+
+def _higher_is_better(actual: Optional[float], target: Optional[float]) -> Optional[float]:
+    """Score = (Actual / Target) * 100, capped at 100 (RULE 0)."""
+    if actual is None or target in (None, 0):
+        return None
+    return _clamp((actual / target) * 100.0)
+
+
+def _lower_is_better(actual: Optional[float], target: Optional[float]) -> Optional[float]:
+    """Score = 100 if Actual <= Target else (Target / Actual) * 100 (RULE 0)."""
+    if actual is None or target in (None, 0):
+        return None
+    if actual <= target:
+        return 100.0
+    return _clamp((target / actual) * 100.0)
+
+
+def _weighted(components: List[tuple[Optional[float], float]]) -> Optional[float]:
+    """Weighted composite. Caps each subscore at 100 before weighting (CONSTRAINT 6).
+
+    Returns None if any required component is missing — callers handle documented
+    fallbacks (e.g. Rule 9 redistribution) before calling this.
+    """
+    total = 0.0
+    for value, weight in components:
+        if value is None:
+            return None
+        total += _clamp(value) * weight
+    return _clamp(total)
+
+
+# ---------------------------------------------------------------------------
+# Typed inputs
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ScoringInputs:
+    """All raw inputs the rules may consume. Every field is optional; missing
+    inputs cause the dependent score to be flagged incomplete, never estimated."""
+
+    # Scoring scope. "daily" applies SCORING.md targets verbatim. "meal" scales
+    # daily intake targets down by meal_divisor so a single dish is judged against
+    # a fair per-meal share (mirrors the spec's sodium 767mg = 2300÷3 fallback).
+    # See "MEAL-LEVEL SCORING MODE" in SCORING.md.
+    level: str = "daily"
+    meal_divisor: float = 3.0
+
+    # Demographics / profile
+    sex: Optional[str] = None  # "male" / "female"
+    body_weight_kg: Optional[float] = None
+
+    # Nutrition intake (Rules 1–6)
+    protein_g: Optional[float] = None
+    fiber_g: Optional[float] = None
+    calories_consumed: Optional[float] = None
+    added_sugar_g: Optional[float] = None
+    sat_fat_g: Optional[float] = None
+    sodium_mg: Optional[float] = None
+    sodium_meal_mg: Optional[float] = None
+
+    # Calorie targets (Rule 3 / 5 / 6)
+    provider_calorie_target: Optional[float] = None
+    maintenance_calories: Optional[float] = None
+
+    # Hydration (Rule 7)
+    water_l: Optional[float] = None
+    active_minutes: Optional[float] = None
+    temperature_f: Optional[float] = None
+
+    # Sleep (Rule 8)
+    sleep_hours: Optional[float] = None
+    sleep_efficiency_pct: Optional[float] = None
+    sleep_timing_variation_min: Optional[float] = None
+    sleep_debt_hours: Optional[float] = None
+
+    # Activity (Rule 9)
+    steps: Optional[float] = None
+    weekly_exercise_sessions: Optional[float] = None
+    current_activity_level: Optional[float] = None
+    baseline_activity_level: Optional[float] = None
+
+    # Glucose / CGM (Rule 10)
+    cgm_connected: bool = False
+    cgm_consent: bool = False
+    tir_pct: Optional[float] = None
+    glucose_cv_pct: Optional[float] = None
+    post_meal_rise_mg: Optional[float] = None
+    mean_glucose_mg: Optional[float] = None
+    time_above_range_pct: Optional[float] = None
+
+    # Externally-supplied subscores / signals used by composites (Rules 11–18).
+    # These are not derivable from raw biometrics; supplied by the provider/app.
+    glycemic_load_score: Optional[float] = None
+    recovery_signal_score: Optional[float] = None
+    nutrition_consistency_score: Optional[float] = None
+    meal_timing_consistency_score: Optional[float] = None
+    engagement_score: Optional[float] = None
+    protocol_fit_score: Optional[float] = None
+    body_state_fit_score: Optional[float] = None
+    historical_response_fit_score: Optional[float] = None
+    preference_fit_score: Optional[float] = None
+    satiety_score: Optional[float] = None
+    glucose_impact_score: Optional[float] = None
+    energy_impact_score: Optional[float] = None
+    recovery_support_score: Optional[float] = None
+
+    # Behavioral drift (Rule 14): baseline vs current pairs.
+    drift_nutrition: Optional[tuple[float, float]] = None  # (baseline, current)
+    drift_activity: Optional[tuple[float, float]] = None
+    drift_sleep: Optional[tuple[float, float]] = None
+    drift_high_risk_meal: Optional[float] = None  # already-scored 0–100 increase
+    drift_engagement: Optional[tuple[float, float]] = None
+    drift_meal_timing_variability: Optional[float] = None  # already-scored 0–100
+
+    # Recommendation confidence (Rule 18).
+    nutrition_data_completeness: Optional[float] = None
+    wearable_coverage: Optional[float] = None
+    user_history_depth: Optional[float] = None
+    similar_meal_evidence: Optional[float] = None
+    past_prediction_accuracy: Optional[float] = None
+    context_completeness: Optional[float] = None
+    missing_data_penalty: float = 0.0
+
+
+# ---------------------------------------------------------------------------
+# Foundation scores (Rules 1–10)
+# ---------------------------------------------------------------------------
+
+
+def _meal_scale(i: ScoringInputs) -> float:
+    """Divisor applied to daily targets when scoring a single meal (else 1)."""
+    return i.meal_divisor if i.level == "meal" and i.meal_divisor else 1.0
+
+
+def protein_adequacy(i: ScoringInputs) -> ScoreResult:
+    if i.protein_g is None:
+        return ScoreResult("Protein Adequacy", None, False, "no protein intake")
+    target = 100.0
+    if i.body_weight_kg:
+        target = max(100.0, 1.2 * i.body_weight_kg)  # daily floor never below 100g
+    target /= _meal_scale(i)  # meal mode scales the daily floor down
+    return ScoreResult("Protein Adequacy", _higher_is_better(i.protein_g, target), True)
+
+
+def fiber_adequacy(i: ScoringInputs) -> ScoreResult:
+    if i.fiber_g is None:
+        return ScoreResult("Fiber Adequacy", None, False, "no fiber intake")
+    if i.calories_consumed:
+        # Calorie-based target is already portion-proportional; no extra scaling.
+        target = 14.0 * (i.calories_consumed / 1000.0)
+    else:
+        target = 30.0 / _meal_scale(i)  # default daily 30g, scaled for meal mode
+    return ScoreResult("Fiber Adequacy", _higher_is_better(i.fiber_g, target), True)
+
+
+def _calorie_target(i: ScoringInputs) -> Optional[float]:
+    # Provider target overrides all (CONSTRAINT 8). Never mix provider + default.
+    # A provider target is taken as-is (provider may set it per-meal); defaults
+    # are daily and get scaled down in meal mode. Sugar/sat-fat targets derive
+    # from this value, so they inherit the meal scaling automatically.
+    if i.provider_calorie_target:
+        return i.provider_calorie_target
+    if i.maintenance_calories:
+        return (i.maintenance_calories * 0.85) / _meal_scale(i)  # maintenance −15%
+    if i.sex:
+        base = 1600.0 if i.sex.lower().startswith("f") else 1900.0
+        return base / _meal_scale(i)
+    return None
+
+
+def calorie_alignment(i: ScoringInputs) -> ScoreResult:
+    target = _calorie_target(i)
+    if i.calories_consumed is None or target in (None, 0):
+        return ScoreResult("Calorie Alignment", None, False, "no calorie data/target")
+    diff_pct = abs(i.calories_consumed - target) / target * 100.0
+    return ScoreResult("Calorie Alignment", _clamp(100.0 - diff_pct), True)
+
+
+def sodium_control(i: ScoringInputs) -> ScoreResult:
+    if i.sodium_mg is not None:
+        return ScoreResult("Sodium Control", _lower_is_better(i.sodium_mg, 2300.0), True)
+    if i.sodium_meal_mg is not None:  # meal-level fallback only when daily absent
+        return ScoreResult("Sodium Control", _lower_is_better(i.sodium_meal_mg, 767.0), True)
+    return ScoreResult("Sodium Control", None, False, "no sodium data")
+
+
+def added_sugar_control(i: ScoringInputs) -> ScoreResult:
+    cal_target = _calorie_target(i)
+    if i.added_sugar_g is None or cal_target in (None, 0):
+        return ScoreResult("Added Sugar Control", None, False, "no sugar/calorie target")
+    sugar_g_target = (cal_target * 0.10) / 4.0  # 4 cal/g, fixed
+    return ScoreResult("Added Sugar Control", _lower_is_better(i.added_sugar_g, sugar_g_target), True)
+
+
+def saturated_fat_control(i: ScoringInputs) -> ScoreResult:
+    cal_target = _calorie_target(i)
+    if i.sat_fat_g is None or cal_target in (None, 0):
+        return ScoreResult("Saturated Fat Control", None, False, "no sat fat/calorie target")
+    fat_g_target = (cal_target * 0.10) / 9.0  # 9 cal/g, fixed
+    return ScoreResult("Saturated Fat Control", _lower_is_better(i.sat_fat_g, fat_g_target), True)
+
+
+def hydration_alignment(i: ScoringInputs) -> ScoreResult:
+    if i.water_l is None:
+        return ScoreResult("Hydration Alignment", None, False, "no water intake")
+    # Female default when sex unknown (conservative baseline).
+    base = 3.7 if (i.sex and i.sex.lower().startswith("m")) else 2.7
+    target = base
+    if i.active_minutes:
+        # +0.25L per 30 active minutes or fraction thereof (ceil).
+        import math
+        target += 0.25 * math.ceil(i.active_minutes / 30.0)
+    if i.temperature_f is not None and i.temperature_f > 80:
+        target += 0.5
+    return ScoreResult("Hydration Alignment", _higher_is_better(i.water_l, target), True)
+
+
+def sleep_quality(i: ScoringInputs) -> ScoreResult:
+    # All four subscores required — do not skip and redistribute (constraint).
+    if None in (
+        i.sleep_hours,
+        i.sleep_efficiency_pct,
+        i.sleep_timing_variation_min,
+        i.sleep_debt_hours,
+    ):
+        return ScoreResult("Sleep Quality", None, False, "incomplete sleep metrics")
+
+    h = i.sleep_hours
+    if 7 <= h <= 9:
+        duration = 100.0
+    elif h < 7:
+        duration = _clamp((h / 7.0) * 100.0)
+    else:
+        duration = _clamp((9.0 / h) * 100.0)
+
+    efficiency = _clamp((i.sleep_efficiency_pct / 85.0) * 100.0)  # target fixed 85%
+
+    v = i.sleep_timing_variation_min
+    consistency = 100.0 if v <= 60 else _clamp((60.0 / v) * 100.0)
+
+    debt = 100.0 if i.sleep_debt_hours <= 0 else _clamp(100.0 - (i.sleep_debt_hours * 15.0))
+
+    value = (duration * 0.35) + (efficiency * 0.30) + (consistency * 0.20) + (debt * 0.15)
+    return ScoreResult("Sleep Quality", _clamp(value), True)
+
+
+def _sleep_consistency_subscore(i: ScoringInputs) -> Optional[float]:
+    v = i.sleep_timing_variation_min
+    if v is None:
+        return None
+    return 100.0 if v <= 60 else _clamp((60.0 / v) * 100.0)
+
+
+def activity_alignment(i: ScoringInputs) -> ScoreResult:
+    steps = _higher_is_better(i.steps, 8000.0)
+    active = _higher_is_better(i.active_minutes, 21.0)
+    sessions = _higher_is_better(i.weekly_exercise_sessions, 2.0)
+
+    if i.baseline_activity_level:
+        baseline = _higher_is_better(i.current_activity_level, i.baseline_activity_level)
+        value = _weighted(
+            [(steps, 0.30), (active, 0.30), (sessions, 0.20), (baseline, 0.20)]
+        )
+    else:
+        # Redistribute baseline's 20% across the other three (rule fallback).
+        value = _weighted([(steps, 0.37), (active, 0.37), (sessions, 0.26)])
+
+    if value is None:
+        return ScoreResult("Activity Alignment", None, False, "incomplete activity metrics")
+    return ScoreResult("Activity Alignment", value, True)
+
+
+def glucose_stability(i: ScoringInputs) -> ScoreResult:
+    # CGM gating is binary: connection AND consent both required (CONSTRAINT 3).
+    if not (i.cgm_connected and i.cgm_consent):
+        return ScoreResult("Glucose Stability", None, False, "CGM not connected/consented")
+    if None in (
+        i.tir_pct,
+        i.glucose_cv_pct,
+        i.post_meal_rise_mg,
+        i.mean_glucose_mg,
+        i.time_above_range_pct,
+    ):
+        return ScoreResult("Glucose Stability", None, False, "incomplete CGM metrics")
+
+    tir = _clamp((i.tir_pct / 70.0) * 100.0)
+    variability = 100.0 if i.glucose_cv_pct <= 36 else _clamp((36.0 / i.glucose_cv_pct) * 100.0)
+    post_meal = 100.0 if i.post_meal_rise_mg <= 40 else _clamp((40.0 / i.post_meal_rise_mg) * 100.0)
+    mean_glucose = _clamp(100.0 - (abs(i.mean_glucose_mg - 100.0) / 100.0 * 100.0))
+    tar = 100.0 if i.time_above_range_pct <= 25 else _clamp((25.0 / i.time_above_range_pct) * 100.0)
+
+    value = (tir * 0.35) + (variability * 0.25) + (post_meal * 0.20) + (mean_glucose * 0.10) + (tar * 0.10)
+    return ScoreResult("Glucose Stability", _clamp(value), True)
+
+
+# ---------------------------------------------------------------------------
+# Composite scores (Rules 11–18)
+# ---------------------------------------------------------------------------
+
+
+def nutrition_quality(i: ScoringInputs, f: Dict[str, ScoreResult]) -> ScoreResult:
+    value = _weighted(
+        [
+            (f["protein"].value, 0.25),
+            (f["fiber"].value, 0.20),
+            (f["calorie"].value, 0.15),
+            (i.glycemic_load_score, 0.15),  # must be scored first (constraint)
+            (f["added_sugar"].value, 0.10),
+            (f["sat_fat"].value, 0.10),
+            (f["sodium"].value, 0.05),
+        ]
+    )
+    if value is None:
+        return ScoreResult("Nutrition Quality", None, False, "missing component scores")
+    return ScoreResult("Nutrition Quality", value, True)
+
+
+def body_state(i: ScoringInputs, f: Dict[str, ScoreResult]) -> ScoreResult:
+    # Determine CGM status FIRST, then lock the weight set (constraint).
+    cgm = i.cgm_connected and i.cgm_consent
+    if cgm:
+        value = _weighted(
+            [
+                (f["sleep"].value, 0.25),
+                (f["activity"].value, 0.20),
+                (i.recovery_signal_score, 0.15),
+                (i.nutrition_consistency_score, 0.15),
+                (f["hydration"].value, 0.10),
+                (f["glucose"].value, 0.15),
+            ]
+        )
+    else:
+        value = _weighted(
+            [
+                (f["sleep"].value, 0.29),
+                (f["activity"].value, 0.24),
+                (i.recovery_signal_score, 0.22),
+                (i.nutrition_consistency_score, 0.20),
+                (f["hydration"].value, 0.05),
+            ]
+        )
+    if value is None:
+        return ScoreResult("Body State", None, False, "missing component scores")
+    return ScoreResult("Body State", value, True)
+
+
+def glp1_protocol_alignment(i: ScoringInputs, f: Dict[str, ScoreResult]) -> ScoreResult:
+    # Engagement defaults to 0 when unknown (constraint), never assumed 100.
+    engagement = i.engagement_score if i.engagement_score is not None else 0.0
+    value = _weighted(
+        [
+            (f["nutrition_quality"].value, 0.25),
+            (f["protein"].value, 0.20),
+            (f["activity"].value, 0.15),
+            (f["hydration"].value, 0.10),
+            (_sleep_consistency_subscore(i), 0.10),
+            (i.meal_timing_consistency_score, 0.10),
+            (engagement, 0.10),
+        ]
+    )
+    if value is None:
+        return ScoreResult("GLP-1 Protocol Alignment", None, False, "missing component scores")
+    return ScoreResult("GLP-1 Protocol Alignment", value, True)
+
+
+def _decline(pair: Optional[tuple[float, float]]) -> Optional[float]:
+    """Decline score: ((baseline - current) / baseline) * 100, floored at 0."""
+    if pair is None:
+        return None
+    baseline, current = pair
+    if not baseline:
+        return None
+    return _clamp(((baseline - current) / baseline) * 100.0)
+
+
+def behavioral_drift(i: ScoringInputs) -> ScoreResult:
+    components = [
+        (_decline(i.drift_nutrition), 0.25),
+        (_decline(i.drift_activity), 0.20),
+        (_decline(i.drift_sleep), 0.15),
+        (i.drift_high_risk_meal, 0.15),
+        (_decline(i.drift_engagement), 0.15),
+        (i.drift_meal_timing_variability, 0.10),
+    ]
+    value = _weighted(components)
+    if value is None:
+        return ScoreResult("Behavioral Drift", None, False, "no baseline/drift data")
+    band = "Low" if value <= 30 else "Moderate" if value <= 60 else "High"
+    # NOTE: risk score — higher = worse. Not inverted here (constraint).
+    return ScoreResult("Behavioral Drift", value, True, f"{band} Drift")
+
+
+def meal_alignment(i: ScoringInputs, f: Dict[str, ScoreResult]) -> ScoreResult:
+    # Historical response defaults to 50 (neutral) when unavailable (constraint).
+    historical = i.historical_response_fit_score if i.historical_response_fit_score is not None else 50.0
+    value = _weighted(
+        [
+            (f["nutrition_quality"].value, 0.35),
+            (i.protocol_fit_score, 0.25),
+            (i.body_state_fit_score, 0.15),
+            (historical, 0.15),
+            (i.preference_fit_score, 0.10),
+        ]
+    )
+    if value is None:
+        return ScoreResult("Meal Alignment", None, False, "missing component scores")
+    return ScoreResult("Meal Alignment", value, True)
+
+
+def predicted_meal_impact(i: ScoringInputs, f: Dict[str, ScoreResult]) -> ScoreResult:
+    historical = i.historical_response_fit_score if i.historical_response_fit_score is not None else 50.0
+    value = _weighted(
+        [
+            (f["meal_alignment"].value, 0.30),
+            (i.satiety_score, 0.20),
+            (i.glucose_impact_score, 0.20),
+            (i.energy_impact_score, 0.15),
+            (i.recovery_support_score, 0.10),
+            (historical, 0.05),
+        ]
+    )
+    if value is None:
+        return ScoreResult("Predicted Meal Impact", None, False, "missing component scores")
+    return ScoreResult("Predicted Meal Impact", value, True)
+
+
+def overall_adherence(i: ScoringInputs, f: Dict[str, ScoreResult]) -> ScoreResult:
+    drift = f["behavioral_drift"].value
+    drift_control = None if drift is None else _clamp(100.0 - drift)  # invert (constraint)
+    engagement = i.engagement_score if i.engagement_score is not None else 0.0
+    cgm = i.cgm_connected and i.cgm_consent
+    if cgm:
+        value = _weighted(
+            [
+                (f["glp1"].value, 0.30),
+                (f["nutrition_quality"].value, 0.20),
+                (f["activity"].value, 0.15),
+                (f["sleep"].value, 0.10),
+                (engagement, 0.10),
+                (f["glucose"].value, 0.10),
+                (drift_control, 0.05),
+            ]
+        )
+    else:
+        value = _weighted(
+            [
+                (f["glp1"].value, 0.34),
+                (f["nutrition_quality"].value, 0.24),
+                (f["activity"].value, 0.17),
+                (f["sleep"].value, 0.10),
+                (engagement, 0.10),
+                (drift_control, 0.05),
+            ]
+        )
+    if value is None:
+        return ScoreResult("Overall Adherence", None, False, "missing component scores")
+    return ScoreResult("Overall Adherence", value, True)
+
+
+def recommendation_confidence(i: ScoringInputs) -> ScoreResult:
+    base = _weighted(
+        [
+            (i.nutrition_data_completeness, 0.25),
+            (i.wearable_coverage, 0.20),
+            (i.user_history_depth, 0.20),
+            (i.similar_meal_evidence, 0.15),
+            (i.past_prediction_accuracy, 0.10),
+            (i.context_completeness, 0.10),
+        ]
+    )
+    if base is None:
+        return ScoreResult("Recommendation Confidence", None, False, "missing confidence inputs")
+    # Penalty always applied, even if small (constraint); floor at 0.
+    value = _clamp(base - i.missing_data_penalty)
+    note = "LOW CONFIDENCE — data-quality warning" if value < 50 else ""
+    return ScoreResult("Recommendation Confidence", value, True, note)
+
+
+# ---------------------------------------------------------------------------
+# Orchestration
+# ---------------------------------------------------------------------------
+
+
+def compute_scores(inputs: ScoringInputs) -> Dict[str, ScoreResult]:
+    """Compute all rules in dependency order (foundation before composites)."""
+    f: Dict[str, ScoreResult] = {}
+
+    # Foundation (Rules 1–10)
+    f["protein"] = protein_adequacy(inputs)
+    f["fiber"] = fiber_adequacy(inputs)
+    f["calorie"] = calorie_alignment(inputs)
+    f["sodium"] = sodium_control(inputs)
+    f["added_sugar"] = added_sugar_control(inputs)
+    f["sat_fat"] = saturated_fat_control(inputs)
+    f["hydration"] = hydration_alignment(inputs)
+    f["sleep"] = sleep_quality(inputs)
+    f["activity"] = activity_alignment(inputs)
+    f["glucose"] = glucose_stability(inputs)
+
+    # Composites (Rules 11–18) — order matters.
+    f["nutrition_quality"] = nutrition_quality(inputs, f)
+    f["body_state"] = body_state(inputs, f)
+    f["glp1"] = glp1_protocol_alignment(inputs, f)
+    f["behavioral_drift"] = behavioral_drift(inputs)
+    f["meal_alignment"] = meal_alignment(inputs, f)
+    f["predicted_meal_impact"] = predicted_meal_impact(inputs, f)
+    f["overall_adherence"] = overall_adherence(inputs, f)
+    f["recommendation_confidence"] = recommendation_confidence(inputs)
+    return f
+
+
+# ---------------------------------------------------------------------------
+# Extraction layer — map a user_context dict to ScoringInputs
+# ---------------------------------------------------------------------------
+
+# Candidate biometric signal keys (case-insensitive) per input. user_service's
+# /body-signals payload is keyed by signal name; we tolerate naming variants and
+# leave the input None (→ incomplete score) when no candidate matches.
+_SIGNAL_KEYS: Dict[str, List[str]] = {
+    "protein_g": ["protein", "protein_g", "protein_consumed"],
+    "fiber_g": ["fiber", "fiber_g", "dietary_fiber"],
+    "calories_consumed": ["calories", "calories_consumed", "energy_intake", "kcal"],
+    "added_sugar_g": ["added_sugar", "added_sugar_g", "sugar_added"],
+    "sat_fat_g": ["saturated_fat", "sat_fat", "saturated_fat_g"],
+    "sodium_mg": ["sodium", "sodium_mg"],
+    "water_l": ["water", "water_l", "hydration", "water_intake"],
+    "active_minutes": ["active_minutes", "active_min", "exercise_minutes"],
+    "temperature_f": ["temperature", "temp_f", "ambient_temp"],
+    "sleep_hours": ["sleep_hours", "sleep_duration", "sleep"],
+    "sleep_efficiency_pct": ["sleep_efficiency", "sleep_efficiency_pct"],
+    "sleep_timing_variation_min": ["sleep_timing_variation", "sleep_consistency_min"],
+    "sleep_debt_hours": ["sleep_debt", "sleep_debt_hours"],
+    "steps": ["steps", "step_count", "daily_steps"],
+    "weekly_exercise_sessions": ["weekly_exercise_sessions", "exercise_sessions"],
+    "current_activity_level": ["current_activity_level", "activity_level"],
+    "baseline_activity_level": ["baseline_activity_level", "activity_baseline"],
+    "tir_pct": ["time_in_range", "tir", "tir_pct"],
+    "glucose_cv_pct": ["glucose_cv", "glucose_variability", "cv"],
+    "post_meal_rise_mg": ["post_meal_rise", "glucose_excursion"],
+    "mean_glucose_mg": ["mean_glucose", "average_glucose"],
+    "time_above_range_pct": ["time_above_range", "tar", "tar_pct"],
+    "body_weight_kg": ["weight", "body_weight", "weight_kg"],
+}
+
+
+def _lookup_signal(biometrics: Dict[str, Any], candidates: List[str]) -> Optional[float]:
+    if not biometrics:
+        return None
+    lowered = {str(k).lower(): v for k, v in biometrics.items()}
+    for cand in candidates:
+        entry = lowered.get(cand)
+        if entry is None:
+            continue
+        value = entry.get("value") if isinstance(entry, dict) else entry
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            continue
+    return None
+
+
+def inputs_from_context(ctx: Optional[Dict[str, Any]]) -> ScoringInputs:
+    """Build ScoringInputs from a fetch_user_context() dict. Unmapped fields
+    stay None so their scores are flagged incomplete rather than estimated."""
+    inputs = ScoringInputs()
+    if not ctx:
+        return inputs
+
+    profile = ctx.get("profile") or {}
+    biometrics = ctx.get("biometrics") or {}
+    providers = [str(p).lower() for p in (ctx.get("connected_providers") or [])]
+
+    # Profile-derived
+    sex = profile.get("sex") or profile.get("gender")
+    if isinstance(sex, str) and sex.strip():
+        inputs.sex = sex
+    for wkey in ("body_weight_kg", "weight_kg", "weight"):
+        if profile.get(wkey):
+            try:
+                inputs.body_weight_kg = float(profile[wkey])
+                break
+            except (TypeError, ValueError):
+                pass
+
+    # Biometric-derived
+    for field_name, candidates in _SIGNAL_KEYS.items():
+        if getattr(inputs, field_name) is not None:
+            continue
+        val = _lookup_signal(biometrics, candidates)
+        if val is not None:
+            setattr(inputs, field_name, val)
+
+    # CGM gating: a connected CGM provider implies connection + consent (the
+    # provider link is only created after the user consents in user_service).
+    cgm = any("cgm" in p or "dexcom" in p or "libre" in p for p in providers)
+    inputs.cgm_connected = cgm
+    inputs.cgm_consent = cgm
+
+    return inputs
+
+
+# ---------------------------------------------------------------------------
+# Prompt formatting
+# ---------------------------------------------------------------------------
+
+# Scores surfaced to Kai's prompt, in the order most useful for ranking meals.
+# Composites lead (richest signal) but only appear when their inputs are complete;
+# foundation scores follow so Kai still gets usable signal from biometrics alone.
+_PROMPT_ORDER = [
+    ("overall_adherence", "Overall Adherence"),
+    ("body_state", "Body State"),
+    ("nutrition_quality", "Nutrition Quality"),
+    ("glp1", "GLP-1 Protocol Alignment"),
+    ("behavioral_drift", "Behavioral Drift (risk: higher=worse)"),
+    ("recommendation_confidence", "Recommendation Confidence"),
+    ("protein", "Protein Adequacy"),
+    ("fiber", "Fiber Adequacy"),
+    ("calorie", "Calorie Alignment"),
+    ("added_sugar", "Added Sugar Control"),
+    ("sat_fat", "Saturated Fat Control"),
+    ("sodium", "Sodium Control"),
+    ("hydration", "Hydration Alignment"),
+    ("sleep", "Sleep Quality"),
+    ("activity", "Activity Alignment"),
+    ("glucose", "Glucose Stability"),
+]
+
+
+def format_scores_block(scores: Dict[str, ScoreResult]) -> str:
+    """Render computed scores for prompt injection. Empty string if none are
+    complete — the block is only added when there's real signal."""
+    lines: List[str] = []
+    for key, label in _PROMPT_ORDER:
+        result = scores.get(key)
+        if result and result.complete and result.value is not None:
+            suffix = f" — {result.note}" if result.note else ""
+            lines.append(f"- {label}: {result.value:.0f}%{suffix}")
+    if not lines:
+        return ""
+    header = (
+        "KAI HEALTH SCORES (0–100, computed from the user's data; higher is better "
+        "except where noted). Use these to weight and justify recommendations — "
+        "favor meals that support low scores. Do not recite the numbers verbatim."
+    )
+    return header + "\n" + "\n".join(lines)
+
+
+def score_context(ctx: Optional[Dict[str, Any]]) -> str:
+    """Convenience: context dict → prompt-ready score block."""
+    return format_scores_block(compute_scores(inputs_from_context(ctx)))
+
+
+# ---------------------------------------------------------------------------
+# Serialization (for persistence)
+# ---------------------------------------------------------------------------
+
+
+def serialize_scores(scores: Dict[str, ScoreResult]) -> Dict[str, Any]:
+    """Flatten ScoreResults to a JSON-safe dict for storage."""
+    return {
+        key: {"name": r.name, "value": r.value, "complete": r.complete, "note": r.note}
+        for key, r in scores.items()
+    }
+
+
+def deserialize_scores(data: Dict[str, Any]) -> Dict[str, ScoreResult]:
+    """Rebuild ScoreResults from stored JSON (inverse of serialize_scores)."""
+    return {
+        key: ScoreResult(
+            name=d.get("name", key),
+            value=d.get("value"),
+            complete=d.get("complete", False),
+            note=d.get("note", ""),
+        )
+        for key, d in (data or {}).items()
+    }

--- a/tools/test_scoring.py
+++ b/tools/test_scoring.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""
+Unit tests for the Kai MAI scoring engine (scoring.py).
+
+Pure math — no network. Run: python3 tools/test_scoring.py
+Verifies formula correctness, caps/floors, CGM gating, and missing-data flagging
+against the hard rules in SCORING.md.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from scoring import (  # noqa: E402
+    ScoringInputs,
+    compute_scores,
+    inputs_from_context,
+    protein_adequacy,
+    fiber_adequacy,
+    calorie_alignment,
+    sodium_control,
+    added_sugar_control,
+    saturated_fat_control,
+    hydration_alignment,
+    sleep_quality,
+    activity_alignment,
+    glucose_stability,
+    behavioral_drift,
+    recommendation_confidence,
+)
+
+_passed = 0
+_failed = 0
+
+
+def check(label, got, expected, tol=0.5):
+    global _passed, _failed
+    if expected is None:
+        ok = got is None
+    elif got is None:
+        ok = False
+    else:
+        ok = abs(got - expected) <= tol
+    if ok:
+        _passed += 1
+        print(f"  PASS  {label}  (got {got})")
+    else:
+        _failed += 1
+        print(f"  FAIL  {label}  expected {expected}, got {got}")
+
+
+def main():
+    global _passed, _failed
+    # RULE 1 — protein: target = max(100, 1.2*kg). 90/120 -> 75.
+    check("protein 90g @ 100kg", protein_adequacy(ScoringInputs(protein_g=90, body_weight_kg=100)).value, 75)
+    # Cap at 100, light user never below 100g target.
+    check("protein cap", protein_adequacy(ScoringInputs(protein_g=200, body_weight_kg=50)).value, 100)
+    check("protein missing", protein_adequacy(ScoringInputs()).value, None)
+
+    # RULE 2 — fiber default 30g. 15/30 -> 50.
+    check("fiber 15g", fiber_adequacy(ScoringInputs(fiber_g=15)).value, 50)
+    # Calorie-based: 14g/1000cal at 2000cal -> target 28; 28/28 -> 100.
+    check("fiber cal-based", fiber_adequacy(ScoringInputs(fiber_g=28, calories_consumed=2000)).value, 100)
+
+    # RULE 3 — calorie alignment proximity. female default 1600; 1440 -> diff 10% -> 90.
+    check("calorie align", calorie_alignment(ScoringInputs(calories_consumed=1440, sex="female")).value, 90)
+    # Over and under penalize equally.
+    check("calorie over", calorie_alignment(ScoringInputs(calories_consumed=1760, sex="female")).value, 90)
+    # Provider target overrides default.
+    check("calorie provider", calorie_alignment(ScoringInputs(calories_consumed=2000, sex="female", provider_calorie_target=2000)).value, 100)
+
+    # RULE 4 — sodium lower-is-better. Under target -> 100. 4600 -> 50.
+    check("sodium under", sodium_control(ScoringInputs(sodium_mg=2000)).value, 100)
+    check("sodium over", sodium_control(ScoringInputs(sodium_mg=4600)).value, 50)
+    # Meal-level fallback only when daily absent (767mg target).
+    check("sodium meal fallback", sodium_control(ScoringInputs(sodium_meal_mg=767)).value, 100)
+
+    # RULE 5 — sugar target = (cal*10%)/4. 1600cal -> 40g target. 80g -> 50.
+    check("sugar control", added_sugar_control(ScoringInputs(added_sugar_g=80, sex="female")).value, 50)
+
+    # RULE 6 — sat fat target = (cal*10%)/9. Male default 1900cal -> 21.11g. 40g -> 52.78.
+    check("sat fat control", saturated_fat_control(ScoringInputs(sat_fat_g=40, sex="male")).value, 52.78)
+
+    # RULE 7 — hydration. male base 3.7 + 30min activity (0.25) + heat (0.5) = 4.45; 4.45 -> 100.
+    check("hydration adjusted", hydration_alignment(ScoringInputs(water_l=4.45, sex="male", active_minutes=30, temperature_f=85)).value, 100)
+    # Unknown sex -> female base 2.7. 1.35 -> 50.
+    check("hydration default sex", hydration_alignment(ScoringInputs(water_l=1.35)).value, 50)
+
+    # RULE 8 — sleep composite. Perfect inputs -> 100.
+    perfect_sleep = ScoringInputs(sleep_hours=8, sleep_efficiency_pct=85, sleep_timing_variation_min=30, sleep_debt_hours=0)
+    check("sleep perfect", sleep_quality(perfect_sleep).value, 100)
+    # Missing one subscore -> incomplete (no redistribution).
+    check("sleep incomplete", sleep_quality(ScoringInputs(sleep_hours=8, sleep_efficiency_pct=85)).value, None)
+    # Sleep debt floors at 0: 8h debt -> debt subscore 0.
+    debt_sleep = ScoringInputs(sleep_hours=8, sleep_efficiency_pct=85, sleep_timing_variation_min=30, sleep_debt_hours=8)
+    # duration100*.35 + eff100*.30 + cons100*.20 + debt0*.15 = 85.
+    check("sleep debt floor", sleep_quality(debt_sleep).value, 85)
+
+    # RULE 9 — activity with baseline missing -> redistribute weights, still scores.
+    act = activity_alignment(ScoringInputs(steps=8000, active_minutes=21, weekly_exercise_sessions=2))
+    check("activity no baseline", act.value, 100)
+
+    # RULE 10 — glucose gated: no CGM -> incomplete.
+    check("glucose gated off", glucose_stability(ScoringInputs(tir_pct=80)).value, None)
+    # Perfect with CGM connected+consented -> 100.
+    g = ScoringInputs(cgm_connected=True, cgm_consent=True, tir_pct=70, glucose_cv_pct=36, post_meal_rise_mg=40, mean_glucose_mg=100, time_above_range_pct=25)
+    check("glucose perfect", glucose_stability(g).value, 100)
+
+    # RULE 14 — behavioral drift: nutrition declines 100->50 = 50% decline.
+    drift = behavioral_drift(ScoringInputs(
+        drift_nutrition=(100, 50), drift_activity=(100, 100), drift_sleep=(100, 100),
+        drift_high_risk_meal=0, drift_engagement=(100, 100), drift_meal_timing_variability=0,
+    ))
+    # 50*.25 = 12.5 -> Low Drift band.
+    check("behavioral drift", drift.value, 12.5)
+    assert "Low" in drift.note, "drift band note"
+
+    # RULE 18 — confidence with penalty applied and floored.
+    conf = recommendation_confidence(ScoringInputs(
+        nutrition_data_completeness=100, wearable_coverage=100, user_history_depth=100,
+        similar_meal_evidence=100, past_prediction_accuracy=100, context_completeness=100,
+        missing_data_penalty=10,
+    ))
+    check("confidence w/ penalty", conf.value, 90)
+
+    # MEAL-LEVEL MODE — daily targets scaled by meal_divisor (default 3).
+    # Protein: daily floor 100 / 3 = 33.3 target; 42g meal -> capped 100.
+    check("meal protein", protein_adequacy(ScoringInputs(level="meal", protein_g=42)).value, 100)
+    # Same 42g in daily mode scores against 100g floor -> 42.
+    check("daily protein", protein_adequacy(ScoringInputs(level="daily", protein_g=42)).value, 42)
+    # Fiber default 30/3 = 10 target; 10g meal -> 100.
+    check("meal fiber", fiber_adequacy(ScoringInputs(level="meal", fiber_g=10)).value, 100)
+    # Calorie female default 1600/3 = 533 target; 533cal meal -> 100.
+    check("meal calorie", calorie_alignment(ScoringInputs(level="meal", sex="female", calories_consumed=533)).value, 100)
+    # Provider target taken as-is even in meal mode (assumed per-meal).
+    check("meal provider as-is", calorie_alignment(ScoringInputs(level="meal", sex="female", calories_consumed=500, provider_calorie_target=500)).value, 100)
+
+    # Extraction layer: maps biometric signal keys, leaves unknowns None.
+    ctx = {
+        "profile": {"sex": "female", "weight_kg": 70},
+        "biometrics": {
+            "protein": {"value": 84, "unit": "g"},
+            "Steps": {"value": 8000},
+        },
+        "connected_providers": ["dexcom_cgm"],
+    }
+    extracted = inputs_from_context(ctx)
+    check("extract protein", extracted.protein_g, 84)
+    check("extract steps (case-insensitive)", extracted.steps, 8000)
+    assert extracted.cgm_connected and extracted.cgm_consent, "CGM provider implies consent"
+    assert extracted.fiber_g is None, "unmapped input stays None"
+
+    # Full pipeline runs without raising; foundation feeds composites.
+    scores = compute_scores(extracted)
+    assert "overall_adherence" in scores, "composite present"
+    # target = max(100, 1.2*70=84) = 100 (floor); 84/100 -> 84.
+    check("protein via pipeline", scores["protein"].value, 84)
+
+    # Serialize round-trip preserves values and rebuilds the same prompt block.
+    from scoring import serialize_scores, deserialize_scores, format_scores_block
+    payload = serialize_scores(scores)
+    assert isinstance(payload["protein"]["value"], float), "serialized value is JSON-safe"
+    rebuilt = deserialize_scores(payload)
+    assert format_scores_block(rebuilt) == format_scores_block(scores), "round-trip block matches"
+    _passed += 1
+    print("  PASS  serialize round-trip")
+
+    print(f"\n{_passed} passed, {_failed} failed")
+    sys.exit(1 if _failed else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/user_context.py
+++ b/user_context.py
@@ -1,0 +1,254 @@
+"""
+User Context - Fetches a user's health profile, connected devices, and latest
+wearable (Spike) biometrics from the user_service microservice REST API, and
+formats them for prompt injection.
+
+Calls user_service over HTTP (not its database) so the service boundary and
+schema stay owned by user_service. Authenticated with a short-lived service
+JWT signed with the shared TOKEN_SECRET (Buildly RAD Core pattern).
+
+Fail-safe: any error (service down, auth, missing user) returns None / "" so
+the chat flow is never broken; the profile block is only added when available.
+"""
+
+import os
+import json
+import time
+import logging
+from typing import Optional, Dict, Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# Base URL of the user_service microservice, e.g. http://localhost:8001
+USER_SERVICE_URL = os.getenv("USER_SERVICE_URL", "").rstrip("/")
+# Shared secret used to sign the service JWT (matches user_service TOKEN_SECRET).
+USER_SERVICE_TOKEN_SECRET = os.getenv("USER_SERVICE_TOKEN_SECRET", "")
+# How long the minted service token is valid (seconds).
+_TOKEN_TTL = 300
+_HTTP_TIMEOUT = httpx.Timeout(5.0, connect=2.0)
+
+
+def resolve_identity(authorization: Optional[str]) -> tuple[Optional[str], Optional[str]]:
+    """Extract (core_user_uuid, raw_token) from an incoming Bearer JWT.
+
+    The identity is taken from the signed token, never from client-supplied
+    request fields, so a caller cannot request another user's health data.
+    Returns (None, None) when no usable identity is present.
+    """
+    if not authorization or not authorization.startswith("Bearer "):
+        return None, None
+    token = authorization.split("Bearer ", 1)[1].strip()
+    if not token:
+        return None, None
+
+    try:
+        import jwt
+    except ImportError:
+        logger.warning("PyJWT not installed; cannot verify identity token")
+        return None, None
+
+    payload = None
+    if USER_SERVICE_TOKEN_SECRET:
+        try:
+            payload = jwt.decode(token, USER_SERVICE_TOKEN_SECRET, algorithms=["HS256"])
+        except Exception as e:
+            logger.warning("Identity token verification failed: %s", e)
+
+    if payload is None:
+        # Dev-only escape hatch: accept unverified tokens when explicitly enabled.
+        if os.getenv("ALLOW_UNVERIFIED_JWT", "false").lower() == "true":
+            try:
+                payload = jwt.decode(token, options={"verify_signature": False})
+            except Exception as e:
+                logger.warning("Unverified token decode failed: %s", e)
+                return None, None
+        else:
+            return None, None
+
+    return payload.get("core_user_uuid"), token
+
+
+def _mint_service_token(core_user_uuid: str) -> Optional[str]:
+    """Mint a short-lived JWT carrying core_user_uuid for user_service auth."""
+    if not USER_SERVICE_TOKEN_SECRET:
+        return None
+    try:
+        import jwt
+    except ImportError:
+        logger.warning("PyJWT not installed; cannot authenticate to user_service")
+        return None
+
+    payload = {
+        "core_user_uuid": core_user_uuid,
+        "username": "babblebeaver-service",
+        "exp": int(time.time()) + _TOKEN_TTL,
+    }
+    return jwt.encode(payload, USER_SERVICE_TOKEN_SECRET, algorithm="HS256")
+
+
+async def fetch_user_context(
+    core_user_uuid: str, bearer_token: Optional[str] = None
+) -> Optional[Dict[str, Any]]:
+    """Fetch profile + connected providers + latest biometrics over HTTP.
+
+    Args:
+        core_user_uuid: identity to fetch context for.
+        bearer_token: optional end-user JWT to forward; if omitted a service
+            token is minted from USER_SERVICE_TOKEN_SECRET.
+    """
+    if not USER_SERVICE_URL or not core_user_uuid:
+        return None
+
+    token = bearer_token or _mint_service_token(core_user_uuid)
+    if not token:
+        logger.warning("No token available for user_service; skipping context")
+        return None
+
+    headers = {"Authorization": f"Bearer {token}"}
+    params = {"core_user_uuid": core_user_uuid}
+
+    try:
+        async with httpx.AsyncClient(
+            base_url=USER_SERVICE_URL, headers=headers, timeout=_HTTP_TIMEOUT
+        ) as client:
+            profile_resp = await client.get("/userprofile/", params=params)
+            if profile_resp.status_code != 200:
+                logger.warning(
+                    "user_service /userprofile returned %s", profile_resp.status_code
+                )
+                return None
+            profiles = profile_resp.json()
+            # DRF list endpoint may paginate; handle list or {results: [...]}.
+            if isinstance(profiles, dict):
+                profiles = profiles.get("results", [])
+            if not profiles:
+                return None
+            profile = profiles[0]
+
+            signals_resp = await client.get(
+                "/body-signals/", params={**params, "period": "month"}
+            )
+            biometrics = signals_resp.json() if signals_resp.status_code == 200 else {}
+
+            providers_resp = await client.get("/connectedprovider/", params=params)
+            providers = (
+                providers_resp.json() if providers_resp.status_code == 200 else []
+            )
+            if isinstance(providers, dict):
+                providers = providers.get("results", [])
+    except Exception as e:
+        logger.warning("Failed to fetch user context from user_service: %s", e)
+        return None
+
+    return {
+        # Full profile passthrough — any new field added to user_service's
+        # UserProfile shows up here automatically, no code change required.
+        "profile": profile if isinstance(profile, dict) else {},
+        "connected_providers": [
+            p.get("provider_slug") for p in providers if p.get("provider_slug")
+        ],
+        "biometrics": biometrics if isinstance(biometrics, dict) else {},
+    }
+
+
+# Internal/plumbing fields that should never be surfaced to the prompt.
+_PROFILE_SKIP_FIELDS = {
+    "id", "user_uuid", "core_user_uuid", "created_at", "updated_at",
+    "push_token", "user",
+    # Notification toggles — not relevant to nutrition reasoning.
+    "push_notifications_enabled", "email_alerts_enabled",
+    "dhub_notifications_enabled",
+}
+# Preferred ordering for known fields; anything else is appended afterwards.
+_PROFILE_FIELD_ORDER = [
+    "full_name", "glp1_medication", "dietary_preferences", "health_goals",
+    "is_nutritionist", "is_premium",
+]
+
+
+def format_user_context(ctx: Optional[Dict[str, Any]]) -> str:
+    """Render the context dict into a prompt block. Empty string if no data.
+
+    Schema-agnostic: every non-empty profile field returned by user_service is
+    surfaced, so new fields (location, weather prefs, MAI signals, etc.) appear
+    automatically without changing this code.
+    """
+    if not ctx:
+        return ""
+
+    profile = ctx.get("profile") or {}
+    lines = ["USER HEALTH PROFILE:"]
+
+    ordered_keys = [k for k in _PROFILE_FIELD_ORDER if k in profile]
+    ordered_keys += [k for k in profile if k not in _PROFILE_FIELD_ORDER]
+
+    for key in ordered_keys:
+        if key in _PROFILE_SKIP_FIELDS:
+            continue
+        value = profile.get(key)
+        if not _has_value(value):
+            continue
+        lines.append(f"- {_humanize(key)}: {_compact(value)}")
+
+    if ctx.get("connected_providers"):
+        lines.append(f"- Connected Devices: {', '.join(ctx['connected_providers'])}")
+
+    bios = ctx.get("biometrics") or {}
+    if bios:
+        readings = ", ".join(
+            f"{sig}={_fmt_num(d.get('value'))}{d.get('unit', '')}"
+            for sig, d in bios.items()
+            if isinstance(d, dict)
+        )
+        as_of = next(
+            (d.get("recorded_at", "")[:10] for d in bios.values() if isinstance(d, dict)),
+            "",
+        )
+        if readings:
+            lines.append(f"- Recent Biometrics (as of {as_of}): {readings}")
+
+    # Only a header and nothing else means no usable data.
+    return "\n".join(lines) if len(lines) > 1 else ""
+
+
+def _has_value(value: Any) -> bool:
+    """True if a field holds meaningful data worth showing the model."""
+    if value is None:
+        return False
+    if isinstance(value, bool):
+        # Only surface flags that are on (e.g. "Nutritionist: True"); a False
+        # flag is noise.
+        return value
+    if isinstance(value, str):
+        return value.strip() not in ("", '""')
+    if isinstance(value, (list, dict)):
+        return len(value) > 0
+    return True
+
+
+def _humanize(key: str) -> str:
+    """snake_case -> Title Case, with a few nicer special cases."""
+    overrides = {
+        "glp1_medication": "GLP-1 Medication",
+        "full_name": "Name",
+        "is_nutritionist": "Nutritionist",
+        "is_premium": "Premium Member",
+        "mai_signals": "MAI Signals",
+    }
+    return overrides.get(key, key.replace("_", " ").title())
+
+
+def _compact(value: Any) -> str:
+    if isinstance(value, (dict, list)):
+        return json.dumps(value, separators=(", ", ": "))
+    return str(value)
+
+
+def _fmt_num(v: Any) -> str:
+    try:
+        f = float(v)
+        return str(int(f)) if f.is_integer() else str(f)
+    except (TypeError, ValueError):
+        return str(v)


### PR DESCRIPTION
Implements SCORING.md (18 deterministic rules + meal-level mode) in scoring.py, persists per-day score snapshots via daily_scores.py and a DailyScore model, and injects a health-score block into Kai's prompt to weight recommendations. Adds user_context biometrics fetch and scoring unit tests.

Excludes credential JSON files via .gitignore.